### PR TITLE
Support for main instead of master

### DIFF
--- a/ghtt/assignment.py
+++ b/ghtt/assignment.py
@@ -275,7 +275,6 @@ def create_repos(ctx, source, yes, students=None, groups=None):
             has_projects=False,
         )
 
-        # dangerous because we use methods with _
         default_branch = ghtt.config.get('default-branch', 'master')
         g_repo.edit(default_branch=default_branch)
 

--- a/ghtt/assignment.py
+++ b/ghtt/assignment.py
@@ -285,6 +285,9 @@ def create_repos(ctx, source, yes, students=None, groups=None):
             subprocess.check_call(["git", "checkout", default_branch], cwd=source)
         except subprocess.CalledProcessError:
             click.secho(f"The branch `{default_branch}` does not exist in the source repository. Please specify the correct source branch in `ghtt.yaml` using the `default-branch` keyword.")
+            if ghtt.config.get('default-branch', None) is None:
+                click.secho(f"\n\nYou typically want to add the \"main\" branch as default in `ghtt.yaml`, like this:")
+                click.secho(f"\ndefault-branch: main", fg="blue")
             raise
         subprocess.call(["git", "branch", "-D", repo.name], cwd=source)
         subprocess.check_call(["git", "checkout", "-b", repo.name], cwd=source)

--- a/ghtt/search.py
+++ b/ghtt/search.py
@@ -17,7 +17,7 @@ def notify(api_key, domain_name, to, repos, query):
     text = ""
     for g_repo in repos:
         text = text + g_repo.html_url
-        g_commit = g_repo.get_branch("master").commit
+        g_commit = g_repo.get_branch(g_repo.master_branch or "master").commit
         text = text + "\nMetadata of last commit:"
         text = text + "\n\tAuthor name: {}".format(g_commit.commit.author.name)
         text = text + "\n\tAuthor email: {}".format(g_commit.commit.author.email)
@@ -84,7 +84,7 @@ def search(ctx, query, mg_api_key, mg_domain, to):
         click.secho(g_repo.html_url, fg="red")
 
         click.secho("Metadata of last commit:")
-        g_commit = g_repo.get_branch("master").commit
+        g_commit = g_repo.get_branch(g_repo.master_branch or "master").commit
         click.secho("\tAuthor name: {}".format(g_commit.commit.author.name))
         click.secho("\tAuthor email: {}\n".format(g_commit.commit.author.email))
 

--- a/ghtt/search.py
+++ b/ghtt/search.py
@@ -17,7 +17,7 @@ def notify(api_key, domain_name, to, repos, query):
     text = ""
     for g_repo in repos:
         text = text + g_repo.html_url
-        g_commit = g_repo.get_branch(g_repo.master_branch or "master").commit
+        g_commit = g_repo.get_branch(g_repo.default_branch).commit
         text = text + "\nMetadata of last commit:"
         text = text + "\n\tAuthor name: {}".format(g_commit.commit.author.name)
         text = text + "\n\tAuthor email: {}".format(g_commit.commit.author.email)
@@ -84,7 +84,7 @@ def search(ctx, query, mg_api_key, mg_domain, to):
         click.secho(g_repo.html_url, fg="red")
 
         click.secho("Metadata of last commit:")
-        g_commit = g_repo.get_branch(g_repo.master_branch or "master").commit
+        g_commit = g_repo.get_branch(g_repo.default_branch).commit
         click.secho("\tAuthor name: {}".format(g_commit.commit.author.name))
         click.secho("\tAuthor email: {}\n".format(g_commit.commit.author.email))
 

--- a/ghtt/util.py
+++ b/ghtt/util.py
@@ -48,23 +48,20 @@ def grep_in(path, strings, no_header=False):
 @util.command()
 @click.argument("source", required="True")
 @click.option(
-    '--branch',
-    help='branch',
-    default='master')
-@click.option(
     '--at', '-a',
     help='Time at which to show repository')
 @click.option(
     '--rm-repo', '-r',
     help="Use this flag when you only want the files without the repository",
     is_flag=True)
-def branches_to_folders(source, branch, at=None, rm_repo=False):
+def branches_to_folders(source, at=None, rm_repo=False):
     """Expands a git repository so each branch is in a different folder.
 
     SOURCE: path to git repository
     """
     source = os.path.abspath(source)
     source = source.rstrip("/")
+    # orig_branch = subprocess.check_output(["git", "branch", "--show-current"], cwd=source, universal_newlines=True).strip()
     branches = subprocess.check_output(["git", "for-each-ref", "--format=%(refname:short)", "refs/heads/*"], cwd=source, universal_newlines=True)
     branches = branches.strip().split("\n")
 
@@ -83,4 +80,6 @@ def branches_to_folders(source, branch, at=None, rm_repo=False):
         if rm_repo:
             shutil.rmtree(f"{destination}/.git")
 
-    subprocess.check_call(["git", "checkout", branch], cwd=source)
+    #### removed: not sure why this was here, we never change the original branch?
+    # # return the original repo to its original branch
+    # subprocess.check_call(["git", "checkout", orig_branch], cwd=source)

--- a/ghtt/util.py
+++ b/ghtt/util.py
@@ -61,7 +61,6 @@ def branches_to_folders(source, at=None, rm_repo=False):
     """
     source = os.path.abspath(source)
     source = source.rstrip("/")
-    # orig_branch = subprocess.check_output(["git", "branch", "--show-current"], cwd=source, universal_newlines=True).strip()
     branches = subprocess.check_output(["git", "for-each-ref", "--format=%(refname:short)", "refs/heads/*"], cwd=source, universal_newlines=True)
     branches = branches.strip().split("\n")
 
@@ -80,6 +79,3 @@ def branches_to_folders(source, at=None, rm_repo=False):
         if rm_repo:
             shutil.rmtree(f"{destination}/.git")
 
-    #### removed: not sure why this was here, we never change the original branch?
-    # # return the original repo to its original branch
-    # subprocess.check_call(["git", "checkout", orig_branch], cwd=source)

--- a/ghtt/util.py
+++ b/ghtt/util.py
@@ -48,13 +48,17 @@ def grep_in(path, strings, no_header=False):
 @util.command()
 @click.argument("source", required="True")
 @click.option(
+    '--branch',
+    help='branch',
+    default='master')
+@click.option(
     '--at', '-a',
     help='Time at which to show repository')
 @click.option(
     '--rm-repo', '-r',
     help="Use this flag when you only want the files without the repository",
     is_flag=True)
-def branches_to_folders(source, at=None, rm_repo=False):
+def branches_to_folders(source, branch, at=None, rm_repo=False):
     """Expands a git repository so each branch is in a different folder.
 
     SOURCE: path to git repository
@@ -79,4 +83,4 @@ def branches_to_folders(source, at=None, rm_repo=False):
         if rm_repo:
             shutil.rmtree(f"{destination}/.git")
 
-    subprocess.check_call(["git", "checkout", "master"], cwd=source)
+    subprocess.check_call(["git", "checkout", branch], cwd=source)


### PR DESCRIPTION
When creating repositories that have a `main` branch instead of a `master` branch, ghtt currently fails.

These changes fix that and more:
- For `create-repos`, auto-detect if source branch is `main`  instead of `master`
- Option to manually set source branch (to `main` or something else)
- Allow changing the name of the created branch with `--create-repo-branch main`
- For existing repositories, auto-detect "master branch" for that repo. It's in `g_repo.master_branch`. With safe fallback to `master`.