### PR TITLE
Fix password length assertion error when using token

### DIFF
--- a/ghtt/auth.py
+++ b/ghtt/auth.py
@@ -17,8 +17,8 @@ def authenticate(url, token):
         token = username
         password = click.prompt("{} Password".format(url), hide_input=True)
     else:
-        username = ""
-        password = ""
+        username = None
+        password = None
 
     if not url.startswith("http"):
         url = "https://" + url


### PR DESCRIPTION
Using token authentication caused a `len(password) > 0 AssertionError`. This PR fixes this issue.