### PR TITLE
added --read-only option to remove-grant

### DIFF
--- a/ghtt/assignment.py
+++ b/ghtt/assignment.py
@@ -640,9 +640,5 @@ def remove_grant(ctx, yes, read_only, students=None, groups=None):
         else:
             # Set Read-only repo access
             for username in [s.username for s in repo.students]:
-                current_permission = g_repo.get_collaborator_permission(username)
-                click.secho("'{}' currently has '{}' access".format(username, current_permission))
-                if current_permission == 'read':
-                    continue
                 click.secho("Setting repo access to read-only for '{}' in '{}'".format(username, repo.name), fg="green")
                 g_repo.add_to_collaborators(username, 'pull')

--- a/ghtt/assignment.py
+++ b/ghtt/assignment.py
@@ -598,6 +598,8 @@ def grant(ctx, yes, read_only, students=None, groups=None):
 def remove_grant(ctx, yes, students=None, groups=None):
     """Removes students' access to their repository and cancels any open invitation for that
     student.
+
+    Hint: to remove only push access, but keep read-only access, use the grant command with --read-only to update the existing permissions.
     """
     if students:
         students = [s.strip() for s in students.split(",")]


### PR DESCRIPTION
`remove-grant` currently removes the student for the repo, removing all access.

I've added a `--read-only` option, which instead removes write access to the repo. Students can still create and reply to issues etc.

This is useful after a deadline etc.


(I found this code when cleaning up my ghtt. I used it last year but forgot to make a pull request. Could also be made into a separate command is that is better.)