### PR TITLE
Add config repos.name-template

### DIFF
--- a/docs/examples/project-config/ghtt.yaml
+++ b/docs/examples/project-config/ghtt.yaml
@@ -19,11 +19,11 @@ expected-mentors-per-group: 0
 repos:
   has-issues: True
   has-wiki: False
-  # name_template can be set to customize the names of the generated repo's.
+  # name-template can be set to customize the names of the generated repo's.
   # The template replaces the following fields:
   #   - {organization}: The current organization
   #   - {student_group}: The group of the current student
   #   - {student_username}: The username of the current student
   # Default when not working with groups: '{organization}-{student_username}'
   # Default when working with groups:     '{organization}-{student_group}'
-  name_template: 'my_custom_text-{student_group}'
+  name-template: 'my_custom_text-{student_group}'

--- a/docs/examples/project-config/ghtt.yaml
+++ b/docs/examples/project-config/ghtt.yaml
@@ -19,3 +19,11 @@ expected-mentors-per-group: 0
 repos:
   has-issues: True
   has-wiki: False
+  # name_template can be set to customize the names of the generated repo's.
+  # The template replaces the following fields:
+  #   - {organization}: The current organization
+  #   - {student_group}: The group of the current student
+  #   - {student_username}: The username of the current student
+  # Default when not working with groups: '{organization}-{student_username}'
+  # Default when working with groups:     '{organization}-{student_group}'
+  name_template: 'my_custom_text-{student_group}'

--- a/ghtt/config.py
+++ b/ghtt/config.py
@@ -112,8 +112,8 @@ def get_organization() -> str:
     return urlparse(get("url", None)).path.rstrip("/").rsplit("/", 1)[-1]
 
 
-def make_repo_name(template: str, organisation: str, student_username: str, student_group: Optional[str]) -> str:
-    res = template.replace('{organisation}', organisation).replace('{student_username}', student_username)
+def make_repo_name(template: str, organization: str, student_username: str, student_group: Optional[str]) -> str:
+    res = template.replace('{organization}', organization).replace('{student_username}', student_username)
     if student_group:
         res = res.replace('{student_group}', student_group)
     return res
@@ -137,11 +137,11 @@ def get_repos(students: List[Person], mentors: Optional[List[Person]] = None) ->
             if not student.group:
                 click.secho("{} is not a member of any group; skipping.".format(student.username))
                 continue
-            reponame_template = get('repos.name_template', '{organisation}-{student_group}')
+            reponame_template = get('repos.name_template', '{organization}-{student_group}')
             reponame = make_repo_name(reponame_template, organization, student.username, student.group)
             repo = repos.get(reponame, StudentRepo(reponame))
         else:
-            reponame_template = get('repos.name_template', '{organisation}-{student_username}')
+            reponame_template = get('repos.name_template', '{organization}-{student_username}')
             reponame = make_repo_name(reponame_template, organization, student.username, student.group)
             repo = StudentRepo(reponame)
         repo.students.append(student)

--- a/ghtt/config.py
+++ b/ghtt/config.py
@@ -137,11 +137,11 @@ def get_repos(students: List[Person], mentors: Optional[List[Person]] = None) ->
             if not student.group:
                 click.secho("{} is not a member of any group; skipping.".format(student.username))
                 continue
-            reponame_template = get('repos.name_template', '{organization}-{student_group}')
+            reponame_template = get('repos.name-template', '{organization}-{student_group}')
             reponame = make_repo_name(reponame_template, organization, student.username, student.group)
             repo = repos.get(reponame, StudentRepo(reponame))
         else:
-            reponame_template = get('repos.name_template', '{organization}-{student_username}')
+            reponame_template = get('repos.name-template', '{organization}-{student_username}')
             reponame = make_repo_name(reponame_template, organization, student.username, student.group)
             repo = StudentRepo(reponame)
         repo.students.append(student)

--- a/ghtt/config.py
+++ b/ghtt/config.py
@@ -112,6 +112,13 @@ def get_organization() -> str:
     return urlparse(get("url", None)).path.rstrip("/").rsplit("/", 1)[-1]
 
 
+def make_repo_name(template: str, organisation: str, student_username: str, student_group: Optional[str]) -> str:
+    res = template.replace('{organisation}', organisation).replace('{student_username}', student_username)
+    if student_group:
+        res = res.replace('{student_group}', student_group)
+    return res
+
+
 def get_repos(students: List[Person], mentors: Optional[List[Person]] = None) -> Dict[str, StudentRepo]:
     if mentors is None:
         mentors = []
@@ -130,16 +137,13 @@ def get_repos(students: List[Person], mentors: Optional[List[Person]] = None) ->
             if not student.group:
                 click.secho("{} is not a member of any group; skipping.".format(student.username))
                 continue
-            reponame = "{}-{}".format(
-                organization,
-                student.group
-            )
+            reponame_template = get('repos.name_template', '{organisation}-{student_group}')
+            reponame = make_repo_name(reponame_template, organization, student.username, student.group)
             repo = repos.get(reponame, StudentRepo(reponame))
         else:
-            repo = StudentRepo("{}-{}".format(
-                organization,
-                student.username
-            ))
+            reponame_template = get('repos.name_template', '{organisation}-{student_username}')
+            reponame = make_repo_name(reponame_template, organization, student.username, student.group)
+            repo = StudentRepo(reponame)
         repo.students.append(student)
         repo.group = student.group
         repo.comment = ", ".join([s.comment for s in repo.students])


### PR DESCRIPTION
This add config option `repos.name-template`.
It allows changing the name of the generated repos. Currently that name is a hardcoded value based on organization and student group or name.

Example usage:
```
repos:
   name-template: '{organization}-custom-part-of-repo-name-{student_group}'
```

The template takes the following fields:
- `{organization}`: The current organization
- `{student_group}`: The group of the current student
- `{student_username}`: The username of the current student

The defaults are fully backward compatible: If you don't set `repos.name-template` in the config,  `ghtt` automatically gives the same names it did before.
