### PR TITLE
Added bulk delete

### DIFF
--- a/ghtt/assignment.py
+++ b/ghtt/assignment.py
@@ -326,10 +326,27 @@ def create_repos(ctx, source, yes, students=None, groups=None):
 @click.option(
     '--groups',
     help='Comma-separated list of group names. Defaults to all groups.')
-def delete_repos(ctx, students=None, groups=None):
+@click.option(
+    '--destroy-data',
+    help='Confirm that you want to use this command that can destroy data.', is_flag=True)
+def delete_repos(ctx, students=None, groups=None, destroy_data=False):
     """Delete student repositories in the organization specified by the url.
 
     WARNING: this is obviously a dangerous operation!"""
+
+    click.secho("*** This command will delete repositories! ***", fg="red")
+    click.secho("*** It will destroy data irrecoverably! ***", fg="red")
+    click.secho("\nLifesaver: Consider using the command \"ghtt assignment rename-repo\" to rename repos "
+                "instead of deleting them.\n", fg="green")
+
+    if not destroy_data:
+        click.secho("Add the command line option --destroy-data to enable the delete-repos command.")
+        exit(1)
+
+    if not ghtt.config.get("enable-repo-delete", False):
+        click.secho("Add the line \"enable-repo-delete: True\" to your ghtt config to enable the delete-repos command.")
+        exit(1)
+
     yes = False  # --yes has been disabled. Better always be safe with delete.
 
     if students:

--- a/ghtt/assignment.py
+++ b/ghtt/assignment.py
@@ -332,7 +332,7 @@ def create_repos(ctx, source, yes, students=None, groups=None):
 def delete_repos(ctx, students=None, groups=None, destroy_data=False):
     """Delete student repositories in the organization specified by the url.
 
-    WARNING: this is obviously a dangerous operation!"""
+    WARNING: this is obviously a dangerous operation! Consider using the command 'ghtt assignment rename repo' to rename repos instead of deleting them."""
 
     click.secho("*** This command will delete repositories! ***", fg="red")
     click.secho("*** It will destroy data irrecoverably! ***", fg="red")

--- a/ghtt/assignment.py
+++ b/ghtt/assignment.py
@@ -354,7 +354,7 @@ def delete_repos(ctx, students=None, groups=None, destroy_data=False):
     if groups:
         groups = [gr.strip() for gr in groups.split(",")]
 
-    click.secho("# Deleting (!!!) student repositories..", fg="red")
+    click.secho("# WARNING! Deleting student repositories. This will permanently remove all code and history of these repositories! For a less destructive way to remove a repository, see 'ghtt assignment rename-repo'.", fg="red")
 
     g : github.Github = ctx.obj['pyg']
     g_org = g.get_organization(ghtt.config.get_organization())


### PR DESCRIPTION
This adds:
```
$ ghtt assignment delete-repos --help
Usage: ghtt assignment delete-repos [OPTIONS]

  Delete student repositories in the organization specified by the url.

  WARNING: this is obviously a dangerous operation!

Options:
  --students TEXT  Comma-separated list of usernames. Defaults to all
                   students.
  --groups TEXT    Comma-separated list of group names. Defaults to all
                   groups.
  --help           Show this message and exit.
```