### PR TITLE
Added command to rename repositories

### DIFF
--- a/ghtt/assignment.py
+++ b/ghtt/assignment.py
@@ -552,10 +552,9 @@ def pull(ctx, source, yes, students=None, groups=None):
     help='New name for repos. This can contain \\1, \\2, ... to match the groups in the regex. Example: "student-\1"')
 @click.option(
     '--yes',
-    help='Process all students/groups, without confirmation.', is_flag=True)
+    help='Process all repositories, without confirmation.', is_flag=True)
 def rename_repo(ctx, yes, match, replace):
-    """Rename organisation repos using regex
-    """
+    """Rename organisation repos using a regex and replacement."""
     pattern = re.compile(match)
 
     click.secho("# Renaming organisation repositories..", fg="green")

--- a/ghtt/assignment.py
+++ b/ghtt/assignment.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-
+import re
 from functools import wraps
 import os
 import subprocess
@@ -540,6 +540,43 @@ def pull(ctx, source, yes, students=None, groups=None):
     finally:
         summary.sort(key=lambda tup: tup[2])
         click.secho(tabulate(summary, headers=['Username', "Description", 'Last commit time', "Committer info", 'Commit summary']))
+
+
+@assignment.command()
+@click.pass_context
+@click.option(
+    '--match',
+    help='Regex to match repos. Example: "studnt-(.*)"')
+@click.option(
+    '--replace',
+    help='New name for repos. This can contain \\1, \\2, ... to match the groups in the regex. Example: "student-\1"')
+@click.option(
+    '--yes',
+    help='Process all students/groups, without confirmation.', is_flag=True)
+def rename_repo(ctx, yes, match, replace):
+    """Rename organisation repos using regex
+    """
+    pattern = re.compile(match)
+
+    click.secho("# Renaming organisation repositories..", fg="green")
+
+    g: github.Github = ctx.obj['pyg']
+    g_org = g.get_organization(ghtt.config.get_organization())
+    g_repos = g_org.get_repos('all')
+
+    asker = ProceedAsker(yes=yes, action='rename repo')
+
+    for g_repo in g_repos:
+        match = pattern.match(g_repo.name)
+        if not match:
+            continue
+
+        replacement = pattern.sub(replace, g_repo.name)
+
+        if not asker.should_proceed(f"{g_repo.url} with name {g_repo.name} to {replacement}"):
+            continue
+
+        g_repo.edit(name=replacement)
 
 
 @assignment.command()


### PR DESCRIPTION
Added a command to rename repositories:

```
$ ghtt assignment rename-repo --help
Usage: ghtt assignment rename-repo [OPTIONS]

  Rename organisation repos using a regex and replacement.

Options:
  --match TEXT    Regex to match repos. Example: "studnt-(.*)"
  --replace TEXT  New name for repos. This can contain \1, \2, ... to match
                  the groups in the regex. Example: "student-"
  --yes           Process all repositories, without confirmation.
  --help          Show this message and exit.
```

```
$ ghtt assignment rename-repo --match 'test-(.*)' --replace 'test2-\1'
# URL: 'https://github.ugent.be/experiment-org'
# Renaming organisation repositories..
Do you want to rename repo "https://github.ugent.be/api/v3/repos/experiment-org/test-repo-1 with name test-repo-1 to test2-repo-1"? (y, all, n, none, abort): y
```

This is a bit different than the commands that work on student repo's, because you might want to work on repo's that don't fit the student repo pattern (since you might have renamed them).

I thought about putting this in `ghtt util rename-repo`, but then the auth gets a bit akward (`--url` and `--token` options move from command to subcommand.):

```
 $ ghtt util rename-repo --help
Usage: ghtt util rename-repo [OPTIONS]

  Rename organisation repos using a regex and replacement.

Options:
  --match TEXT      Regex to match repos. Example: "studnt-(.*)"
  --replace TEXT    New name for repos. This can contain \1, \2, ... to match
                    the groups in the regex. Example: "student-"
  --yes             Process all repositories, without confirmation.
  -u, --url TEXT    URL to Github instance. Defaults to github.com.
  -t, --token TEXT  Github authentication token.
  --help            Show this message and exit.
```

I can refactor if you prefer this.